### PR TITLE
Catch and log connection errors so that troubleshooting is a bit easier

### DIFF
--- a/bin/mmdb_utils.py
+++ b/bin/mmdb_utils.py
@@ -258,9 +258,9 @@ class MaxMindDatabaseUtil(object):
         logger.debug("Downloading the MaxMind DB file.")
         try:
             r = requests.get(MaxMindDatabaseDownloadLink, auth=(account_id, license_key), allow_redirects=True, proxies=proxies)
-        except ConnectionError as connection_error:
-            logger.error("Failed to download DB from %s: %s", MaxMindDatabaseDownloadLink, str(connection_error))
-            raise connection_error
+        except Exception as err:
+            logger.exception("Failed to download MaxMind DB file from {}".format(MaxMindDatabaseDownloadLink))
+            raise err
 
         if r.status_code == 200:
             with open(DB_TEMP_DOWNLOAD, 'wb') as fp:

--- a/bin/mmdb_utils.py
+++ b/bin/mmdb_utils.py
@@ -256,7 +256,11 @@ class MaxMindDatabaseUtil(object):
         # NOTE - Please visit GitHub page (https://github.com/VatsalJagani/Splunk-App-Auto-Update-MaxMind-Database), if you are developer and want to help improving this App in anyways
 
         logger.debug("Downloading the MaxMind DB file.")
-        r = requests.get(MaxMindDatabaseDownloadLink, auth=(account_id, license_key), allow_redirects=True, proxies=proxies)
+        try:
+            r = requests.get(MaxMindDatabaseDownloadLink, auth=(account_id, license_key), allow_redirects=True, proxies=proxies)
+        except ConnectionError as connection_error:
+            logger.error("Failed to download DB from %s: %s", MaxMindDatabaseDownloadLink, str(connection_error))
+            raise connection_error
 
         if r.status_code == 200:
             with open(DB_TEMP_DOWNLOAD, 'wb') as fp:


### PR DESCRIPTION
When connections out to updates.maxmind.com fail, as of now they are passed up to `maxmind_db_update_command.py `and returned as search results and never written to the `auto_update_maxmind_db:logs` sourcetype. This makes it harder to spot and troubleshoot failures. For example, in the example screenshot a firewall was blocking the outbound traffic, but the only hint that this was happening was the lack of a "Downloaded MaxMind DB file" message. 
<img width="750" alt="Screenshot 2024-03-08 at 2 05 23 PM" src="https://github.com/CrossRealms/Splunk-App-Auto-Update-MaxMind-Database/assets/4950661/8bae5ac7-550d-42b9-b9d6-7159b25b1178">

This PR still passes the exception up to `maxmind_db_update_command.py` but also logs it. 